### PR TITLE
feat: replace placeholder with values for LpApis request URL

### DIFF
--- a/src/app/apis/LpApis/LpApis.js
+++ b/src/app/apis/LpApis/LpApis.js
@@ -10,26 +10,41 @@ export { URL } from './apiMap';
 export default class LpApis {
   static [VERSION] = '0.0.1';
 
-  static delete({ data, url }) {
+  static delete({ 
+    data, 
+    param,
+    url, 
+  }) {
     return this.send({
       data,
       method: HttpMethod.DELETE,
+      param,
       url,
     });
   }
 
-  static get({ data, url }) {
+  static get({ 
+    data, 
+    param,
+    url,
+  }) {
     return this.send({
       data,
       method: HttpMethod.GET,
+      param,
       url,
     });
   }
 
-  static post({ data, url }) {
+  static post({ 
+    data, 
+    param,
+    url,
+  }) {
     return this.send({
       data,
       method: HttpMethod.POST,
+      param,
       url,
     });
   }
@@ -37,6 +52,7 @@ export default class LpApis {
   static send({
     data = {},
     method,
+    param,
     url,
   }) {
     if (!method || !url) {
@@ -54,7 +70,7 @@ export default class LpApis {
       return Axios({
         data: dataInContract,
         method,
-        url,
+        url: replace(url, param),
         withCredentials: true,
       });
     } else {
@@ -62,5 +78,12 @@ export default class LpApis {
     }
   }
 };
+
+function replace(url, param = {}) {
+  Object.keys(param).map((k) => {
+    url = url.replace(`:${k}`, param[k]);
+  });
+  return url;
+}
 
 export const VERSION = Symbol('version');

--- a/src/app/apis/LpApis/apiMap.js
+++ b/src/app/apis/LpApis/apiMap.js
@@ -6,7 +6,7 @@ export const URL = {
   COMMENTS: `${ROOT}/comments`,
   DEFINITION_NEW: `${ROOT}/definition/new`,
   DEFINITIONS: `${ROOT}/definitions`,
-  DEFINITIONS_BY_ID: `${ROOT}/definitions/1`,
+  DEFINITIONS_BY_ID: `${ROOT}/definitions/:defId`,
   DEFINITIONS_IDS: `${ROOT}/definitions/ids`,
   NEWDEFINITIONS: `${ROOT}/newdefinitions`,
   SESSION_NEW: `${ROOT}/session/new`,

--- a/src/app/state/actions/definitionActions.js
+++ b/src/app/state/actions/definitionActions.js
@@ -64,6 +64,9 @@ export function requestGetDefinitionsById({
       .basePayload(arguments[0])
       .async(LpApis.post({
         data: arguments[0],
+        param: {
+          defId,
+        },
         url: URL.DEFINITIONS_BY_ID,
       }))
       .fire();


### PR DESCRIPTION
replace() is defined to replace placeholders in URL.

Fixes https://github.com/language-project/language-project/issues/25